### PR TITLE
додано можливість перегляду лайв матчів для ліги

### DIFF
--- a/handler/game_handler.go
+++ b/handler/game_handler.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	e "dota_league/error"
+	"dota_league/model"
+	"dota_league/repository"
+	"log"
+	"strconv"
+)
+
+// GameHandler controll struct
+type GameHandler struct {
+	gameRepository *repository.GameRepositoryInterface
+}
+
+// NewGameHandler create new game handler struct
+func NewGameHandler(gr *repository.GameRepositoryInterface) GamesHandlerInterface {
+	return &GameHandler{gr}
+}
+
+// GetLiveLeagueGames preparing response from db
+func (gh *GameHandler) GetLiveLeagueGames(leagueID string) (*[]model.GameResponse, error) {
+	gameResponse := []model.GameResponse{}
+
+	leagueIDInt, err := strconv.Atoi(leagueID)
+	if err != nil {
+		return &gameResponse, nil
+	}
+
+	gamesFromDb, err := (*gh.gameRepository).GetForLeague(leagueIDInt)
+	if e.IsNotFound(err) {
+		return nil, &e.Error{Code: e.ENOTFOUND, Op: "GameHandler.GetLiveLeagueGames", Err: err}
+	} else if err != nil {
+		log.Printf("GameHandler.GetLiveLeagueGames GetForLeague error %v", err)
+		return nil, &e.Error{Op: "GameHandler.GetLiveLeagueGames", Err: err}
+	}
+
+	//convert model.Game to model.GameResponse
+
+	for _, gameFromDb := range *gamesFromDb {
+		g := model.GameResponse{
+			LeagueID:   gameFromDb.LeagueID,
+			Team1Name:  gameFromDb.RadiantName,
+			Team1ID:    gameFromDb.RadiantTeamID,
+			Team2Name:  gameFromDb.DireName,
+			Team2ID:    gameFromDb.DireTeamID,
+			Spectators: gameFromDb.Spectators,
+		}
+		gameResponse = append(gameResponse, g)
+	}
+
+	return &gameResponse, nil
+}

--- a/handler/game_handler_inteface.go
+++ b/handler/game_handler_inteface.go
@@ -1,0 +1,8 @@
+package handler
+
+import "dota_league/model"
+
+// GamesHandlerInterface interface for leagues handler
+type GamesHandlerInterface interface {
+	GetLiveLeagueGames(leagueID string) (*[]model.GameResponse, error)
+}

--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ func main() {
 	e.Static("/", "./public")
 
 	leaguesHandler := handler.NewLeaguesHandler(&leagueDetailsRepository)
-	delivery.NewLeaguesDelivery(e, &leaguesHandler)
+	gamesHandler := handler.NewGameHandler(&gameRepository)
+	delivery.NewLeaguesDelivery(e, &leaguesHandler, &gamesHandler)
 
 	// Start server
 	e.Logger.Fatal(e.Start(viper.GetString(`server.address`)))

--- a/model/game.go
+++ b/model/game.go
@@ -17,3 +17,13 @@ type Game struct {
 	Spectators    int    `json:"spectators"`
 	DbKey         string `json:"_key,omitempty"`
 }
+
+// GameResponse is used to generate REST response
+type GameResponse struct {
+	LeagueID   int    `json:"league_id"`
+	Team1Name  string `json:"team1_name"`
+	Team1ID    int    `json:"team1_id"`
+	Team2Name  string `json:"team2_name"`
+	Team2ID    int    `json:"team2_id"`
+	Spectators int    `json:"spectators"`
+}

--- a/repository/game_interface.go
+++ b/repository/game_interface.go
@@ -8,5 +8,7 @@ type GameRepositoryInterface interface {
 	StoreAll(games *[]model.Game) error
 
 	GetAll() (*[]model.Game, error)
+	GetForLeague(leagueID int) (*[]model.Game, error)
+
 	RemoveAll() error
 }


### PR DESCRIPTION
для вирішення #6  додав ендпоінт `/leagues/:id/live-games` який повертає список поточних лайв ігор з такими полями:
```
{
  "league_id": 0,
  "team1_name": "",
  "team1_id": 0,
  "team2_name": "",
  "team2_id": 0,
  "spectators": 0
}
```
якщо для запитаної ліги в бд немає матчів, повертається `404`
в разі виникнення помилки повертається код `503`